### PR TITLE
Update mainnet.json with O3 nodes

### DIFF
--- a/src/assets/json/mainnet.json
+++ b/src/assets/json/mainnet.json
@@ -105,6 +105,22 @@
       "locale": "us",
       "port": "8080",
       "type": "RPC"
-    }
+    },
+    {
+      "protocol": "http",
+      "url": "node1.o3.network",
+      "location": "Japan",
+      "address": "54.92.68.52",
+      "locale": "jp",
+      "type": "RPC"
+  },
+  {
+      "protocol": "http",
+      "url": "node2.o3.network",
+      "location": "Japan",
+      "address": "54.249.76.125",
+      "locale": "jp",
+      "type": "RPC"
+  }
   ]
 }


### PR DESCRIPTION
We've set up two nodes that we can personally monitor and will be the main entry point for the Ozone Wallet, we'd like to have these visible on neo network monitor as well so that people can quickly see any issues with up time on the service. 

This helps show decentralization both location wise(Japan), and organization wise with O3 committing to maintain these nodes