### PR TITLE
Updated mainnet.json with new Aphelion information

### DIFF
--- a/docs/assets/mainnet.json
+++ b/docs/assets/mainnet.json
@@ -411,6 +411,42 @@
     "locale": "de",
     "port": "10332",
     "type": "RPC"
-   }
+   },
+   { 
+     "protocol": "http", 
+     "url": "seed1.aphelion-neo.com", 
+     "location": "London", 
+     "address": "35.178.126.129", 
+     "locale": "gb", 
+     "port": "10332", 
+     "type": "RPC" 
+   }, 
+   { 
+     "protocol": "http", 
+     "url": "seed2.aphelion-neo.com", 
+     "location": "Frankfurt", 
+     "address": "18.197.136.206", 
+     "locale": "de", 
+     "port": "10332", 
+     "type": "RPC" 
+   }, 
+   { 
+     "protocol": "http", 
+     "url": "seed3.aphelion-neo.com", 
+     "location": "Seoul", 
+     "address": "52.78.136.233", 
+     "locale": "kr", 
+     "port": "10332", 
+     "type": "RPC" 
+   }, 
+   { 
+     "protocol": "http", 
+     "url": "seed4.aphelion-neo.com", 
+     "location": "Sao Paulo", 
+     "address": "54.233.224.215", 
+     "locale": "br", 
+     "port": "10332", 
+     "type": "RPC" 
+   }    
   ]
 }


### PR DESCRIPTION
Changed domain name being used in order to avoid potential HSTS SSL redirect issues which were rendering the nodes unreachable from some machines.