### PR TITLE
update node locale

### DIFF
--- a/docs/assets/mainnet.json
+++ b/docs/assets/mainnet.json
@@ -301,8 +301,8 @@
     {
       "protocol": "http",
       "url": "rpc1.go.nspcc.ru",
-      "location": "Singapor",
-      "locale": "sg",
+      "location": "Russia",
+      "locale": "ru",
       "port": "10332",
       "type": "RPC"
     },

--- a/docs/assets/mainnet.json
+++ b/docs/assets/mainnet.json
@@ -309,8 +309,8 @@
     {
       "protocol": "http",
       "url": "rpc2.go.nspcc.ru",
-      "location": "London",
-      "locale": "gb",
+      "location": "Russia",
+      "locale": "ru",
       "port": "10332",
       "type": "RPC"
     },


### PR DESCRIPTION
Neo-Go node http://rpc2.go.nspcc.ru:10332 moved from Great Britain to Russia. Asset update in this PR.