### PR TITLE
Added NeoBlocks nodes in The Netherlands

### DIFF
--- a/docs/assets/mainnet.json
+++ b/docs/assets/mainnet.json
@@ -3,6 +3,38 @@
   "pollTime": "5000",
   "sites": [
     {
+      "protocol": "https",
+      "url": "node1.nl.neoblocks.org",
+      "location": "The Netherlands",
+      "port": "443",
+      "locale": "nl",
+      "type": "RPC"
+    },
+    {
+      "protocol": "http",
+      "url": "node1.nl.neoblocks.org",
+      "location": "The Netherlands",
+      "port": "10332",
+      "locale": "nl",
+      "type": "RPC"
+    },
+    {
+      "protocol": "https",
+      "url": "node2.nl.neoblocks.org",
+      "location": "The Netherlands",
+      "port": "443",
+      "locale": "nl",
+      "type": "RPC"
+    },
+    {
+      "protocol": "http",
+      "url": "node2.nl.neoblocks.org",
+      "location": "The Netherlands",
+      "port": "10332",
+      "locale": "nl",
+      "type": "RPC"
+    },
+    {
       "service": "neoScan",
       "url": "https://neoscan.io/api/main_net/v1/",
       "location": "United States",

--- a/docs/assets/mainnet.json
+++ b/docs/assets/mainnet.json
@@ -11,26 +11,10 @@
       "type": "RPC"
     },
     {
-      "protocol": "http",
-      "url": "node1.nl.neoblocks.org",
-      "location": "The Netherlands",
-      "port": "10332",
-      "locale": "nl",
-      "type": "RPC"
-    },
-    {
       "protocol": "https",
       "url": "node2.nl.neoblocks.org",
       "location": "The Netherlands",
       "port": "443",
-      "locale": "nl",
-      "type": "RPC"
-    },
-    {
-      "protocol": "http",
-      "url": "node2.nl.neoblocks.org",
-      "location": "The Netherlands",
-      "port": "10332",
       "locale": "nl",
       "type": "RPC"
     },


### PR DESCRIPTION
We've added two new `v2.10.3` nodes in our data center in The Netherlands with `http` and `https` exposed.