### PR TITLE
replaced hostnames with ips for nspcc neo-go nodes

### DIFF
--- a/docs/assets/mainnet.json
+++ b/docs/assets/mainnet.json
@@ -338,28 +338,28 @@
       "type": "RPC"
     },
     {
-      "protocol": "http",	
-      "url": "rpc2.go.nspcc.ru",	
-      "location": "Russia",	
-      "locale": "ru",	
-      "port": "10332",	
-      "type": "RPC"	
-    },	
-    {	
-      "protocol": "http",	
-      "url": "rpc3.go.nspcc.ru",	
-      "location": "Canada",	
-      "locale": "ca",	
-      "port": "10332",	
-      "type": "RPC"	
+      "protocol": "http",
+      "url": "85.143.173.172",
+      "location": "Russia",
+      "locale": "ru",
+      "port": "10332",
+      "type": "RPC"
     },
-    {	
-      "protocol": "http",	
-      "url": "rpc4.go.nspcc.ru",	
-      "location": "US",	
-      "locale": "us",	
-      "port": "10332",	
-      "type": "RPC"	
+    {
+      "protocol": "http",
+      "url": "159.203.16.100",
+      "location": "Canada",
+      "locale": "ca",
+      "port": "10332",
+      "type": "RPC"
+    },
+    {
+      "protocol": "http",
+      "url": "167.71.153.37",
+      "location": "US",
+      "locale": "us",
+      "port": "10332",
+      "type": "RPC"
     },
     {
       "protocol": "http",


### PR DESCRIPTION
Neo Monitor sees NSPCC neo-go nodes as unreachable while nodes are alive and actively accepting connections. Replacing hostnames with IP-adresses fixes the problem.