### PR TITLE
Fix websockets' RTT and change sort

### DIFF
--- a/src/app/netstats.factory.js
+++ b/src/app/netstats.factory.js
@@ -115,7 +115,24 @@
 
         function sortEndPoints (netStats) {
 
+            function getPriority(type){
+                switch(type) {
+                    case "REST":
+                        return 4;
+                    case "WEBSOCKETS":
+                        return 3;
+                    case "RPC":
+                        return 0;
+                    default:
+                        return 1;
+                }
+            }
+
             netStats.endPoints.sort(function (a, b) {
+
+                if(getPriority(a.type) !== getPriority(b.type)){
+                    return getPriority(b.type) - getPriority(a.type);
+                }
 
                 var c = a.peerCount;
                 var d = b.peerCount;


### PR DESCRIPTION
- Fixes #114 
- Changes the sorting algorithm to put all the protocols other than RPC first. The reasoning behind this is that currently the other protocols are too hard to notice among all the RPC nodes.