### PR TITLE
Update mainnet.json

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -67,22 +67,6 @@
     },
     {
       "protocol": "https",
-      "url": "seed4.switcheo.network",
-      "location": "Singapore",
-      "port": "10331",
-      "locale": "sg",
-      "type": "RPC"
-    },
-    {
-      "protocol": "https",
-      "url": "seed5.switcheo.network",
-      "location": "Singapore",
-      "port": "10331",
-      "locale": "sg",
-      "type": "RPC"
-    },
-    {
-      "protocol": "https",
       "url": "seed1.cityofzion.io",
       "location": "USA",
       "locale": "us",


### PR DESCRIPTION
Remove seeds 4 and 5 for Switcheo which were turned off. High level of redundancy for Neo nodes is no longer required with the current node software being a lot more stable.