### PR TITLE
Remove neologin nodes & pubsub service

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -51,21 +51,6 @@
       "type": "REST"
     },
     {
-      "service": "PubSub",
-      "url": "wss://pubsub.main.neologin.io/",
-      "location": "Ireland",
-      "locale": "ie",
-      "type": "WebSockets"
-    },
-    {
-      "protocol": "https",
-      "url": "main.neologin.io",
-      "location": "Ireland",
-      "port": "443",
-      "locale": "ie",
-      "type": "RPC"
-    },
-    {
       "protocol": "https",
       "url": "seed1.switcheo.network",
       "location": "Singapore",

--- a/testnet.json
+++ b/testnet.json
@@ -10,21 +10,6 @@
       "type": "REST"
     },
     {
-      "service": "PubSub",
-      "url": "wss://pubsub.test.neologin.io/",
-      "location": "Ireland",
-      "locale": "ie",
-      "type": "WebSockets"
-    },
-    {
-      "protocol": "https",
-      "url": "test.neologin.io",
-      "location": "Ireland",
-      "port": "443",
-      "locale": "ie",
-      "type": "RPC"
-    },
-    {
       "protocol": "http",
       "url": "seed1.ngd.network",
       "location": "China",


### PR DESCRIPTION
In preparation for sunsetting the service. These nodes are still operational and will remain so for at least a month, but I think it's best to remove them now so people don't rely on them.