### PR TITLE
Fix CI add-path error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1.1.0
+    - uses: actions/setup-node@v1
       with:
         version: 11.x
     - name: Install dependencies
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1.1.0
+    - uses: actions/setup-node@v1
       with:
         version: 11.x
     - name: Install dependencies


### PR DESCRIPTION
Github has pushed an update to their Github pages infrastructure which has broken their own packages, and because the CI on this repo has them as dependencies it is currently broken as well, reporting the following error on all runs:
```
Error: Unable to process command '##[add-path]/opt/hostedtoolcache/node/11.15.0/x64/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
An example of one of such runs can be seen [here](https://github.com/CityOfZion/neo-mon/pull/124/checks?check_run_id=1466364220)

This PR fixes this by setting these dependencies to follow a moving release instead of keeping them pinned (the behaviour that github itself encourages) to a specific version.